### PR TITLE
Change categories to tags

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -17,7 +17,7 @@ layout: default
         <strong>Tags: </strong>
         {%- for tag in page.tags -%}
           <span style="margin-right: 3px">
-            <a href="/tags/{{ tag }}">{{tag}}</a>
+            <a href="/tags/#{{ tag }}">{{tag}}</a>
           </span>
         {%- endfor -%}
       {%- endif -%}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -13,13 +13,13 @@ layout: default
       {%- if page.author -%}
         • <span itemprop="author" itemscope itemtype="http://schema.org/Person"><span class="p-author h-card" itemprop="name">{{ page.author }}</span></span>
       {%- endif -%}</p>
-      {%- if page.categories -%}
-      <strong>Categories: </strong>
-      {%- for category in page.categories -%}
-        <span style="margin-right: 3px">
-          {{ category }}
-        </span>
-      {%- endfor -%}
+      {%- if page.tags.size > 0 -%}
+        <strong>Tags: </strong>
+        {%- for tag in page.tags -%}
+          <span style="margin-right: 3px">
+            <a href="/tags/{{ tag }}">{{tag}}</a>
+          </span>
+        {%- endfor -%}
       {%- endif -%}
   </header>
 

--- a/_posts/2016-11-30-why-and-how-to-do-unit-testing.markdown
+++ b/_posts/2016-11-30-why-and-how-to-do-unit-testing.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Why And How To Do Unit Testing?"
 date:   2016-11-30 04:48:58 +0000
-categories: bdd tdd unit testing
+tags: bdd tdd unit testing
 author: Amit Sharma
 image: img/bug_with_lens.png
 ---

--- a/_posts/2016-12-07-introducing-infrastructure-mapping.markdown
+++ b/_posts/2016-12-07-introducing-infrastructure-mapping.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Introducing Infrastructure Mapping!"
 date:   2016-12-21 04:48:58 +0000
-categories: bdd devops
+tags: bdd devops
 author: Tim Myerscough
 image: img/cards.png
 ---
@@ -60,7 +60,7 @@ In addition, the following contexts may apply:
 
 Rules around Infrastructure Mapping can be grouped into **categories** that are applicable across most contexts.  Capture and maintain a list of categories to structure the conversation.  We have found it useful to keep blue cards with the rules on and re-use them across sessions.  During an infrastructure mapping session, review each category; decide whether it is relevant and discuss examples and rules around it if necessary.
 
-We use the following categories:
+We use the following tags:
 
 * Routing/Firewall - What servers/ports can you see from the context?
 * Users - What users are configured in the context?
@@ -102,7 +102,7 @@ describe "I am logged onto the webserver" do
     end
 
     describe command("curl http://localhost:8080") do
-      its(:stdout) { should match /Hello World/ }    
+      its(:stdout) { should match /Hello World/ }
     end
 
   end
@@ -125,16 +125,16 @@ Once you have your executable specifications, you can TDD the development of you
 
 ## Benefits ##
 
-Being able to capture requirements as executable specifications is an important part of TDD and Infrastructure as Code.  Infrastructure Mapping provides a focussed, structured conversation around capturing your infrastructure requirements, providing a definition of done that is directly translatable into code.  
+Being able to capture requirements as executable specifications is an important part of TDD and Infrastructure as Code.  Infrastructure Mapping provides a focussed, structured conversation around capturing your infrastructure requirements, providing a definition of done that is directly translatable into code.
 Who Should Attend
 
 Infrastructure Mapping is a DevOps activity: the [3 Amigos](https://www.scrumalliance.org/community/articles/2013/2013-april/introducing-the-three-amigos) analogy still applies, but perhaps now it’s the A-Team!
 
 ![The A-Team]({{ site.url }}/img/Ateam.jpg)
 
-* A **developer** representative brings the knowledge of the application functionality to deliver.  
-* The **operations** representative has the experience of ensuring the application can be kept running effectively.  
-* A **tester** representative will help probe the boundaries of the infrastructure.  
+* A **developer** representative brings the knowledge of the application functionality to deliver.
+* The **operations** representative has the experience of ensuring the application can be kept running effectively.
+* A **tester** representative will help probe the boundaries of the infrastructure.
 * A **security** representative will consider risk and help harden the infrastructure.
 
 ## Timebox ##

--- a/_posts/2016-12-21-docker-windows-internal.markdown
+++ b/_posts/2016-12-21-docker-windows-internal.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Docker for Windows Internal"
 date:   2016-12-07 04:48:58 +0000
-categories: docker devops windows
+tags: docker devops windows
 author: William Sia
 image: img/docker-windows.png
 ---
@@ -19,7 +19,7 @@ The source code for Docker can be found in [here](https://github.com/docker/dock
 
 The way the interfaces are implemented in Go, make it very easy for the core development team to write windows & linux specific implementation while keeping the user interface (the commands line) the same.
 
-Both of windows and linux specific implementation can be found in the same repository. To find out a specific implementation for Linux, just do a search with 
+Both of windows and linux specific implementation can be found in the same repository. To find out a specific implementation for Linux, just do a search with
 ~~~
 // +build !windows
 ~~~
@@ -54,7 +54,7 @@ func getBlkioWriteBpsDevices(config *containertypes.HostConfig) ([]blkiodev.Thro
 ~~~
 {: .language-go}
 
- 
+
 
 This will give you some idea of what functions are not implemented in windows, such as **getSystemCPUUsage** in **stats_collector_windows.go**
 ~~~
@@ -80,7 +80,7 @@ func (s *Collector) getNumberOnlineCPUs() (uint32, error) {
 ~~~
 {: .language-go}
 
-You can also search for 
+You can also search for
 ~~~
 runtime.GOOS == "windows"
 ~~~

--- a/_posts/2017-07-17-the-value-of-faster.markdown
+++ b/_posts/2017-07-17-the-value-of-faster.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "The Value of Faster"
 date:   2017-07-17
-categories: bdd devops
+tags: bdd devops
 author: Nick Jenkins
 image: img/roi_curve_value.png
 ---

--- a/_posts/2017-08-10-using-AWS-API-with-cross-account-role(javascript).markdown
+++ b/_posts/2017-08-10-using-AWS-API-with-cross-account-role(javascript).markdown
@@ -2,12 +2,12 @@
 layout: post
 title:  "Using AWS With Cross Account Role"
 date:   2017-08-14
-categories: javascript aws-sdk
+tags: javascript aws-sdk
 author: Bryan Yu
 image: img/aws_sts.png
 ---
 
-This article highlights the preliminary steps of performing AWS API calls in Javascript for a cross account role. 
+This article highlights the preliminary steps of performing AWS API calls in Javascript for a cross account role.
 
 Setting up for cross account roles is outside the scope of this, so if you need more information on that, visit <a href="https://aws.amazon.com/blogs/security/how-to-enable-cross-account-access-to-the-aws-management-console/">AWS policies and groups for cross account access</a>.
 
@@ -15,25 +15,25 @@ There are a multitude of <a href="http://blog.flux7.com/aws-cross-accounts-acces
 
 In the AWS Console, you can easily switch roles by using a link specific to switching to the cross account role. In code we will need to do something slightly different.
 
-API calls relating to assuming roles can be found in the AWS.STS API <a href="http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/STS.html">here</a>. Essentially you need to use it to generate temporary credentials(access key and secret key) to use for the cross account. These are short lived credentials, so don’t expect it to be valid once it has passed its expiry date. 
+API calls relating to assuming roles can be found in the AWS.STS API <a href="http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/STS.html">here</a>. Essentially you need to use it to generate temporary credentials(access key and secret key) to use for the cross account. These are short lived credentials, so don’t expect it to be valid once it has passed its expiry date.
 
-You should also know the cross account policy role ARN. Unless you already have it, follow the steps below: 
-1. Go into the AWS console 
+You should also know the cross account policy role ARN. Unless you already have it, follow the steps below:
+1. Go into the AWS console
 
 2. Navigate to IAM section
 
 3. Click on the Users tab
 
-4. Click on your username (i.e. joe.bloggs) 
+4. Click on your username (i.e. joe.bloggs)
 ![AWS Username]({{ site.url }}/img/aws_iam_user.png)
 
-5. Click on Permissions 
+5. Click on Permissions
 ![AWS Permissions Tab]({{ site.url }}/img/aws_permissions_tab.png)
 
 6. Click on the policy drop down arrow that corresponds to the Cross Account you intend to get access
 ![AWS Role View]({{ site.url }}/img/aws_cross_account_role.png)
 
-7. Copy the role ARN (see *Resources* field i.e. arn:aws:iam:666666:role/BlahRole) within the JSON 
+7. Copy the role ARN (see *Resources* field i.e. arn:aws:iam:666666:role/BlahRole) within the JSON
 policy document
 
 8. Substitute it as the RoleArn parameter (see code below)

--- a/_posts/2017-09-01-the-scourge-of-silos.markdown
+++ b/_posts/2017-09-01-the-scourge-of-silos.markdown
@@ -2,27 +2,27 @@
 layout: post
 title:  "The Scourge of Silos"
 date:   2017-09-01 04:48:58 +0000
-categories: bdd tdd devops pairing mobbing
+tags: bdd tdd devops pairing mobbing
 author: Hamish Tedeschi
 image: img/silos1.png
 ---
 This is one of those articles that may stir up a bit of angst with people, because essentially it is an opinion piece. Not driven by data, merely driven by what I think works best. It was provoked by a brief conversation on social media and got me thinking about why I think the way I do. The conversation was based on the following post by [Josh Partogi](https://www.linkedin.com/feed/update/urn:li:activity:6308818675763941376), which was on the money:
 
 > Many are talking about devops these days.
-> 
+>
 > * Some think devops is a tool.
 > * Others think it is a department or a job role.
 > * Others think it is about frequent deployment.
 > * While others think devops is bug fixing & development.
-> 
+>
 > The IT industry must be the most confusing industry these days.
 
-Running an Enterprise DevOps & Continuous Delivery consultancy, this is a subject close to my heart. We are an opinionated bunch at [Mechanical Rock](https://www.mechanicalrock.io/) and believe that if you do the dev bit in DevOps right, then the Ops bit becomes a lot easier. Bear with me, I will explain and hopefully close the loop. 
+Running an Enterprise DevOps & Continuous Delivery consultancy, this is a subject close to my heart. We are an opinionated bunch at [Mechanical Rock](https://www.mechanicalrock.io/) and believe that if you do the dev bit in DevOps right, then the Ops bit becomes a lot easier. Bear with me, I will explain and hopefully close the loop.
 
-The way I see it, DevOps is made up of 4 key tenets which give way to a set of practices, tooling or processes. 
+The way I see it, DevOps is made up of 4 key tenets which give way to a set of practices, tooling or processes.
 
 1. Sharing / No Silos: Creating a culture where information is shared and is vital to the success of DevOps, nothing should ever be "someone else's problem".
-2. Culture: DevOps seeks to create a high-trust culture of collaboration through learning and experimentation. 
+2. Culture: DevOps seeks to create a high-trust culture of collaboration through learning and experimentation.
 3. Measure Everything / Fast Feedback: Improvements are based on experimentation. Experimentation relies on accurate information and measurement. Short feedback loops generate more information, more quickly and allow informed decisions to be made.
 4. Automate Everything: automate away the 'drudgery' in the the Development-Operations lifecycle, so people can focus on what they are best at - problem solving.
 
@@ -32,23 +32,23 @@ The rise of the DevOps movement has given us a lot of great tools, such as Docke
 
 Recently, I have seen first hand, at a major financial institution, the direct impact of having a "DevOps Team". The six scrum teams we worked with were developing using a gitflow model and although all the teams had the limitless scale of AWS on offer to them, none could actually use it. Some didn't even know the platform they were deploying their application to (which baffles me for a start, as how are they architecting it correctly?). They would develop on a feature branch, but not be able to continuously build, package, deploy and test that feature on the branch, as the DevOps team hadn't set that up for them and were not part of any of these scrum teams. The scrum teams were forced to merge the changes to `master` and test large volumes of features together towards the end of the sprint, thus increasing the risk of change, making the feedback loop larger and slowing the whole process down considerably.
 
-Wouldn't it be a better situation that the team responsible for the application actually create the infrastructure required as they are building it, using those techniques? The knowledge stays within that team, the architecture is emergent and the power to make positive change is in their own hands. 
+Wouldn't it be a better situation that the team responsible for the application actually create the infrastructure required as they are building it, using those techniques? The knowledge stays within that team, the architecture is emergent and the power to make positive change is in their own hands.
 
-So why do organisations create a DevOps Team, which sits in its own bubble and has its own reporting structure, which essentially look after infrastructure, sometimes as code, in my experience? I think a lot of it comes down to organisational structure and command and control leadership styles. 
+So why do organisations create a DevOps Team, which sits in its own bubble and has its own reporting structure, which essentially look after infrastructure, sometimes as code, in my experience? I think a lot of it comes down to organisational structure and command and control leadership styles.
 
 ![Command and Control Management Picture](/img/commdandcontrol.png)
 
-Command and control assumes a leader knows best and that they know where the organisation is going (goals, outcomes) and have a plan for how to get there (process). With a term as fuzzy as "DevOps", as illustrated by Josh's post, should we expect IT leaders in enterprise organisations, who have gone from Waterfall to Agile and now DevOps to be in touch enough to understand the nuance of it? Not in my experience. 
+Command and control assumes a leader knows best and that they know where the organisation is going (goals, outcomes) and have a plan for how to get there (process). With a term as fuzzy as "DevOps", as illustrated by Josh's post, should we expect IT leaders in enterprise organisations, who have gone from Waterfall to Agile and now DevOps to be in touch enough to understand the nuance of it? Not in my experience.
 
 __So enter matrix management, which was designed to solve all these problems, by creating product centric delivery teams, but still retaining line management.__
 
 ![Matrix Management Picture](/img/matrix-man.png)
 
-The problem with matrix manangement is that it fosters all sorts of nasty things. Political bullshit, being one. In this scenario, a team of individuals from different parts of the organisation are brought together to deliver something. In theory, this is great, but the problem is that line management for these indivduals sits off to one side. Any successes will be attributed to the members of that line manager and inversely any failures will be as a result of the other team members not aligning with that manager. The biggest problem, as a result of this, is the time to make decisions. 
+The problem with matrix manangement is that it fosters all sorts of nasty things. Political bullshit, being one. In this scenario, a team of individuals from different parts of the organisation are brought together to deliver something. In theory, this is great, but the problem is that line management for these indivduals sits off to one side. Any successes will be attributed to the members of that line manager and inversely any failures will be as a result of the other team members not aligning with that manager. The biggest problem, as a result of this, is the time to make decisions.
 
 __It effectively widens the feedback loop (again) by involving interested third parties and will disenfranchise the team actually doing the work.__
 
-The modern equivalent of matrix management in IT teams is the Spotify "Model". Not that it is actually a model at all, if you speak to anyone at Spotify! But expensive consultancies are paid loads to roll out a "model" which effectively propogates this shit. Guilds and tribes may have been formed with good intentions, but are just abused by the middle management that become the issue. 
+The modern equivalent of matrix management in IT teams is the Spotify "Model". Not that it is actually a model at all, if you speak to anyone at Spotify! But expensive consultancies are paid loads to roll out a "model" which effectively propogates this shit. Guilds and tribes may have been formed with good intentions, but are just abused by the middle management that become the issue.
 
 ![Spotify Picture](/img/squadstribes_12.png)
 

--- a/_posts/2017-09-12-repeatable-serverless-applications.markdown
+++ b/_posts/2017-09-12-repeatable-serverless-applications.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Repeatable Serverless Applications"
 date: 2017-09-11
-categories: serverless architecture docker aws
+tags: serverless architecture docker aws
 author: Rick Foxcroft
 image: img/repeatable-serverless-applications/less_servers.png
 ---
@@ -12,14 +12,14 @@ At a recent Mechanical Rock mob programming session we decided to tackle the top
 
 ![serverless benefits]({{ site.url }}/img/repeatable-serverless-applications/serverless_simplifies.png)
 
-Whilst a serverless architecture does alleviate a lot of these mundane tasks, it doesn't necessarily remove the need for them completely. Serverless is scalable and fault tolerant but mainly simplifies many of the operational tasks, associated with traditional architectures.    
+Whilst a serverless architecture does alleviate a lot of these mundane tasks, it doesn't necessarily remove the need for them completely. Serverless is scalable and fault tolerant but mainly simplifies many of the operational tasks, associated with traditional architectures.
 
 
 The preferred approach for any new software project here at Mechanical Rock, is to tackle it with a test-first mindset and a serverless implementation. The difficulty with serverless projects is, they often have dependencies on 3rd party service integrations. As a DevOps consultancy, ideally we would like to practice a Continuous Delivery model on all of our software projects. In order to achieve this, we need to be able test our application locally, on a pipeline and have it run bug-free in the cloud. The good news is, there are tools out there, that can help us achieve this.
 
 ![serverless benefits]({{ site.url }}/img/repeatable-serverless-applications/localstack.png)
 
-Meet, LocalStack. LocalStack, was originally created by Atlassian and has since moved to its own project, found <a href="https://github.com/localstack/localstack">here</a>. LocalStack provides you with "A fully functional local AWS cloud stack". What makes LocalStack so interesting, is that because it is a Docker image with all the traditional AWS serverless services running in the background, one need not litter their codebase with mocking frameworks. Essentially, instead of provisioning mocked services each time your application runs, you bring the LocalStack Docker image up once and your code should run the same locally, as it does in the cloud. You will still need to create resources for your application to use but with a few cheeky bash scripts and some Docker magic, you can automate the provisioning of almost all the necessary resources for your cloud-based application. Sounds too easy? Well you're absolutely right! With a docker-compose file, you can start up the LocalStack service in conjunction with your dev-env in your Dockerfile. 
+Meet, LocalStack. LocalStack, was originally created by Atlassian and has since moved to its own project, found <a href="https://github.com/localstack/localstack">here</a>. LocalStack provides you with "A fully functional local AWS cloud stack". What makes LocalStack so interesting, is that because it is a Docker image with all the traditional AWS serverless services running in the background, one need not litter their codebase with mocking frameworks. Essentially, instead of provisioning mocked services each time your application runs, you bring the LocalStack Docker image up once and your code should run the same locally, as it does in the cloud. You will still need to create resources for your application to use but with a few cheeky bash scripts and some Docker magic, you can automate the provisioning of almost all the necessary resources for your cloud-based application. Sounds too easy? Well you're absolutely right! With a docker-compose file, you can start up the LocalStack service in conjunction with your dev-env in your Dockerfile.
 
 ```yml
 <!-- docker-compose.yml -->
@@ -31,7 +31,7 @@ localstack:
       - "8080:8080"
 ```
 
-In your dockerfile, you can reference a bash script which provisions your AWS resources so that when the docker services are up and running, your resources will be available on the relevant service port referenced on the LocalStack GitHub page. If you would like visibility of the resources available on your 'stack', just hit up http://localhost:8080, in your browser. 
+In your dockerfile, you can reference a bash script which provisions your AWS resources so that when the docker services are up and running, your resources will be available on the relevant service port referenced on the LocalStack GitHub page. If you would like visibility of the resources available on your 'stack', just hit up http://localhost:8080, in your browser.
 
 ```bash
 if [ $ENV = "local" ]; then
@@ -44,7 +44,7 @@ fi
 s3_endpoint = "http://localhost:4572" if os.environ.get("ENV") == "local" else None
 self.s3_resource = boto3.resource('s3', endpoint_url=s3_endpoint)
 ```
-We were using the boto3 library provided by AWS, which allows you to set the endpoint URL of the service you want to talk to when creating a client connection to it. Using this endpoint URL parameter, we were able to establish a connection to our s3 bucket on LocalStack, when the 'ENV' environment variable was set to 'local'. This way, we don't get charged for creating excess and unnecessary resources on our AWS account. 
+We were using the boto3 library provided by AWS, which allows you to set the endpoint URL of the service you want to talk to when creating a client connection to it. Using this endpoint URL parameter, we were able to establish a connection to our s3 bucket on LocalStack, when the 'ENV' environment variable was set to 'local'. This way, we don't get charged for creating excess and unnecessary resources on our AWS account.
 
 If you're hoping to use DynamoDB as a layer of persistence in your application and you are using Python, you may want to use the PynamoDB library which will create a table, if it doesn't already exist. To establish a connection to your local instance of Dynamo, you will have to specify the host name, in the Meta subclass, to point to Dynamo on LocalStack.
 
@@ -54,10 +54,10 @@ class ProductModel(Model):
         table_name = 'Products'
         region = 'ap-southeast-2'
         host = "http://localhost:4569" if os.environ.get(
-            "ENV") == "local" else None 
+            "ENV") == "local" else None
 ```
 
-Since LocalStack is a docker image, with all the AWS services you would typically use, in a cloud native application, you can assume that your application would run the same locally, as it would in the cloud. Subsequently, you should test your application assuming that all the application necessary services are present, when developing locally.  
+Since LocalStack is a docker image, with all the AWS services you would typically use, in a cloud native application, you can assume that your application would run the same locally, as it would in the cloud. Subsequently, you should test your application assuming that all the application necessary services are present, when developing locally.
 
 ```python
 def test_write_data():

--- a/_posts/2017-10-15-the-new-donut.markdown
+++ b/_posts/2017-10-15-the-new-donut.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "The New Donut"
 date:   2017-10-15 04:48:58 +0000
-categories: donut automated test reports
+tags: donut automated test reports
 author: Hamish Tedeschi & Amit Sharma
 image: img/the-new-donut/Donut-01.jpeg
 ---
@@ -11,7 +11,7 @@ Donut was an idea born at [MagenTys](https://magentys.io/) with the intention of
 
 Since inception, the number of contributors has grown and the product roadmap has become clearer. In that time, [Mechanical Rock](https://www.mechanicalrock.io/) was also born. As both [MagenTys](https://magentys.io/) and [Mechanical Rock](https://www.mechanicalrock.io/) are part of the core contributor team and the Donut ecosystem of related projects has grown, it made sense to move it to its own GitHub Organization, similar to how LocalStack has moved from the Atlassian repo to a LocalStack owned one.
 
-The new GitHub Organization is named [Donut Report](https://github.com/DonutReport) and all the projects there (including [Donut](https://github.com/DonutReport/donut)) can be cloned and contributed to in that space. As Donut now supports JUnit XML and NUnit XML, pretty much any test runner out there can produce the output necessary to produce a Donut report. 
+The new GitHub Organization is named [Donut Report](https://github.com/DonutReport) and all the projects there (including [Donut](https://github.com/DonutReport/donut)) can be cloned and contributed to in that space. As Donut now supports JUnit XML and NUnit XML, pretty much any test runner out there can produce the output necessary to produce a Donut report.
 
 If you are a current user of Donut, you may need to make a few small changes to get the latest versions. See the steps below:
 

--- a/_posts/2017-11-22-latency-2017.markdown
+++ b/_posts/2017-11-22-latency-2017.markdown
@@ -2,12 +2,12 @@
 layout: post
 title:  "Latency 2017"
 date:   2017-11-23 04:48:58 +0000
-categories: conferences cloud
+tags: conferences cloud
 author: Hamish Tedeschi
 image: img/latency/Light BG.jpg
 ---
 
-I need to be honest; [Latency](https://latencyconf.io/) was a temporary mental lapse or failure to reason correctly (in other words, a complete and utter brain fart). I need to thank my colleagues at [Mechanical Rock](https://mechanicalrock.io/) for allowing me to go ahead with this idea, despite evidence to the contrary pointing to it being a potential failure. 
+I need to be honest; [Latency](https://latencyconf.io/) was a temporary mental lapse or failure to reason correctly (in other words, a complete and utter brain fart). I need to thank my colleagues at [Mechanical Rock](https://mechanicalrock.io/) for allowing me to go ahead with this idea, despite evidence to the contrary pointing to it being a potential failure.
 
 I had looked around at the conference options in Perth (and the rest of Australia, for that matter) and didn't see much (other than [CukeUpAu](https://cucumber.io/events/cukeup-au-2016), of course) that I would enjoy going to. As a punter, I don't go to a conference to see glitz and glamour (other than perhaps [re:invent](https://reinvent.awsevents.com/)). In actual fact, I like a bit of grime. I go to learn from colleagues and hear about ways to solve problems that I may be facing today or tomorrow. I realise that this also happens when I am in the corridors or outside of the actual talks. Having fun in a safe environment is also a key concern.
 
@@ -15,7 +15,7 @@ It was a big call to run another conference, especially in Perth. So I needed a 
 
 After we had begun the [Latency](https://latencyconf.io/) preparation, I went to [DDDPerth](https://dddperth.com/) with the team, at the Perth Convention Centre. I had a great time - which was a credit to the organisers. The conference scene in Perth was obviously getting more mature and it indicated there is a demand for more progressive, community focused events. I felt renewed enthusiasm that this may be possible after all! **Win number two!**
 
-Running a cloud focused conference in a place where cloud was yet to be adopted seriously was a big call, so we needed support from the major cloud providers, otherwise it would be too risky and just wouldn't make sense. The preference was to have all the major players in town - again, a diverse set of opinions makes for the best experience. Firstly, we approached the team at [AWS](https://aws.amazon.com/) as being a key partner in town, we naturally have contacts there. We had a few hiccups getting approval, but the team were really committed to helping out - Thanks [Andrew](https://www.linkedin.com/in/andrew-winter-43724315/) for driving it through. **Win number three!** 
+Running a cloud focused conference in a place where cloud was yet to be adopted seriously was a big call, so we needed support from the major cloud providers, otherwise it would be too risky and just wouldn't make sense. The preference was to have all the major players in town - again, a diverse set of opinions makes for the best experience. Firstly, we approached the team at [AWS](https://aws.amazon.com/) as being a key partner in town, we naturally have contacts there. We had a few hiccups getting approval, but the team were really committed to helping out - Thanks [Andrew](https://www.linkedin.com/in/andrew-winter-43724315/) for driving it through. **Win number three!**
 
 It wasn't enough to have AWS onboard. We needed more sponsors to help spread the word and provide that extra bit of credibility. Tania suggested [Bankwest](https://www.bankwest.com.au/) may be a possible sponsorship option. That would be huge and completely de-risk the conference from a financial perspective, but also provide that extra publicity we need to get the punters in the door. Again, we had some hiccups getting approval, but Tania persisted and we got there in the end. **Win number four!**
 
@@ -41,11 +41,11 @@ Two weeks out and everything was lining up nicely. The team was following up wit
 
 8.55 AM.. AND WE WERE OFF AND RACING..
 
-[Jan Haak](https://www.linkedin.com/in/haakjan/) "volunteered" to cover the opening space for Charity and the dynamic duo from VGW, [Rhys](https://www.linkedin.com/in/rhysc/) and [Matt](https://www.linkedin.com/in/matthewstephenjames/), stepped in to cover the speaker drop out - and both rocked! **Win number six!** 
+[Jan Haak](https://www.linkedin.com/in/haakjan/) "volunteered" to cover the opening space for Charity and the dynamic duo from VGW, [Rhys](https://www.linkedin.com/in/rhysc/) and [Matt](https://www.linkedin.com/in/matthewstephenjames/), stepped in to cover the speaker drop out - and both rocked! **Win number six!**
 
-[Rob Moore](https://www.linkedin.com/in/robdmoore1/) cranked out a live Azure demo on stage, in place of the second drop out. **Win number seven!** 
+[Rob Moore](https://www.linkedin.com/in/robdmoore1/) cranked out a live Azure demo on stage, in place of the second drop out. **Win number seven!**
 
-And Charity flew in, came straight from the airport and gave the final talk of the day. And CRUSHED it! **Win number eight!** 
+And Charity flew in, came straight from the airport and gave the final talk of the day. And CRUSHED it! **Win number eight!**
 
 **By my count, we won 8/7**
 

--- a/_posts/2017-12-01-networking_Sibling_Docker_Containers.markdown
+++ b/_posts/2017-12-01-networking_Sibling_Docker_Containers.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Networking Between Sibling Docker Containers"
 date:   2017-12-01
-categories: devops docker
+tags: devops docker
 author: Tim Myerscough
 image: img/docker-sibling/docker-network.png
 ---

--- a/_posts/2017-12-02-the-problem-with-bdd.markdown
+++ b/_posts/2017-12-02-the-problem-with-bdd.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "The Highs and Lows of BDD"
 date:   2017-12-02
-categories: bdd quality
+tags: bdd quality
 author: Hamish Tedeschi
 image: img/bug_with_lens.png
 ---

--- a/_posts/2018-01-18-high-code-coverage-is-not-yak-shaving.markdown
+++ b/_posts/2018-01-18-high-code-coverage-is-not-yak-shaving.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "High Code Coverage is not Wasted Effort"
 date:   2018-01-08
-categories: Quality BDD
+tags: Quality BDD
 author: Tim Myerscough
 image: img/yak.png
 ---

--- a/_posts/2018-01-18-high-code-coverage-is-not-yak-shaving.markdown
+++ b/_posts/2018-01-18-high-code-coverage-is-not-yak-shaving.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "High Code Coverage is not Wasted Effort"
 date:   2018-01-08
-tags: Quality BDD
+tags: quality bdd
 author: Tim Myerscough
 image: img/yak.png
 ---

--- a/_posts/2018-03-01-inception-pipelines-pt1.markdown
+++ b/_posts/2018-03-01-inception-pipelines-pt1.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Seeds of Inception - Part 1"
 date:   2018-03-01
-categories: aws continuous deployment
+tags: aws continuous deployment
 author: Pete Yandell
 image: img/inception-pipelines/seed_germination.png
 ---
@@ -39,7 +39,7 @@ While not strictly required, a passing familiarity of Bash Shell scripts, Git, J
 
 ![inception pipeline]({{ site.url }}/img/inception-pipelines/inception-pipeline-cover.png)
 
-At a high-level, the Inception Pipeline works by executing a CloudFormation template which then creates a CodeCommit repository, a CodePipeline pipeline and a few other supporting resources. The first non-source action in the pipeline is a [CloudFormation Deployment Action](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/continuous-delivery-codepipeline.html). 
+At a high-level, the Inception Pipeline works by executing a CloudFormation template which then creates a CodeCommit repository, a CodePipeline pipeline and a few other supporting resources. The first non-source action in the pipeline is a [CloudFormation Deployment Action](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/continuous-delivery-codepipeline.html).
 
 This blog post won't dive deeply into the CloudFormation template (I'll leave that as an exercise for you dear reader), instead I'll just discuss the really juicy bits.
 
@@ -55,7 +55,7 @@ The secret-sauce to the Inception Pipeline is the using the same CloudFormation 
             Provider: 'CloudFormation'
             Version: '1'
         Configuration:
-            ActionMode: 'REPLACE_ON_FAILURE' 
+            ActionMode: 'REPLACE_ON_FAILURE'
             Capabilities: 'CAPABILITY_NAMED_IAM'
             RoleArn: !GetAtt [CloudFormationDeployActionRole, Arn]
             StackName: !Ref StageAdministerPipelineStackName
@@ -108,5 +108,5 @@ I'll wait while you do.
 ![deployed inception pipeline]({{ site.url }}/img/inception-pipelines/inception-pipeline-cover.png)
 
 ## Wrapping Up
- 
+
 If you do end up running an Inception Pipeline please let me know! I'm especially keen to hear any and all improvements, suggestions and critiques.

--- a/_posts/2018-04-01-inception-pipelines-pt2.markdown
+++ b/_posts/2018-04-01-inception-pipelines-pt2.markdown
@@ -13,7 +13,7 @@ image: img/inception-pipelines/seed_germination.png
 
 ## What's The Problem
 
-If you've read my [first post](https://mechanicalrock.github.io//aws/continuous/deployment/2018/03/01/inception-pipelines-pt1) (and you have, haven't you), you either thought "that's absolute crap, why would I bother" or "hey, that's pretty neat, but what can I do with it". If you were the former, then avert your eyes because this post is targeted firmly at the latter.
+If you've read my [first post]({{ site.baseurl }}{% post_url 2018-03-01-inception-pipelines-pt1 %}) (and you have, haven't you), you either thought "that's absolute crap, why would I bother" or "hey, that's pretty neat, but what can I do with it". If you were the former, then avert your eyes because this post is targeted firmly at the latter.
 
 In this post I will be covering how to extend an [Inception Pipeline](https://github.com/MechanicalRock/InceptionPipeline/tree/master) to do something useful. In this instance, it is creating the infrastructure to host a single page application. On the projects I'm currently involved with, this is always the first piece of infrastructure we need (well, after first inceptioning up the pipeline).
 
@@ -26,7 +26,7 @@ In this post I will be covering how to extend an [Inception Pipeline](https://gi
 
 ## What Are The Prerequisites
 
-The obvious first prerequisite is an existing [Inception Pipeline](https://mechanicalrock.github.io//aws/continuous/deployment/2018/03/01/inception-pipelines-pt1). So, if you don't have one, jump across to the original post and create yourself one.
+The obvious first prerequisite is an existing [Inception Pipeline]({{ site.baseurl }}{% post_url 2018-03-01-inception-pipelines-pt1 %}). So, if you don't have one, jump across to the original post and create yourself one.
 
 The next prerequisite is to manually create a couple of AWS resources:
 

--- a/_posts/2018-04-01-inception-pipelines-pt2.markdown
+++ b/_posts/2018-04-01-inception-pipelines-pt2.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Seeds of Inception - Part 2"
 date:   2018-04-01
-categories: aws continuous deployment cdn SPA cloudfront 
+tags: aws continuous deployment cdn SPA cloudfront
 author: Pete Yandell
 image: img/inception-pipelines/seed_germination.png
 ---
@@ -64,7 +64,7 @@ The files are on the Part 2 branch in the [GitHub repository](https://github.com
 
 ## Taking It For A Spin
 
-Getting started is super simple and easy. 
+Getting started is super simple and easy.
 
 1. Add the following parameter to your `aws_seed.json` file. Obviously, you need to replace the value with the CloudFormation stack name of your choosing:
 

--- a/_posts/2018-04-01-inception-pipelines-pt2.markdown
+++ b/_posts/2018-04-01-inception-pipelines-pt2.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Seeds of Inception - Part 2"
 date:   2018-04-01
-tags: aws continuous deployment cdn SPA cloudfront
+tags: aws continuous deployment cdn spa cloudfront
 author: Pete Yandell
 image: img/inception-pipelines/seed_germination.png
 ---

--- a/_posts/2018-05-18-inception-pipelines-pt3.markdown
+++ b/_posts/2018-05-18-inception-pipelines-pt3.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Seeds of Inception - Part 3"
 date:   2018-05-18
-categories: aws continuous deployment cdn SPA cloudfront cross-account
+tags: aws continuous deployment cdn SPA cloudfront cross-account
 author: Pete Yandell
 image: img/inception-pipelines/seed_germination.png
 ---

--- a/_posts/2018-05-18-inception-pipelines-pt3.markdown
+++ b/_posts/2018-05-18-inception-pipelines-pt3.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Seeds of Inception - Part 3"
 date:   2018-05-18
-tags: aws continuous deployment cdn SPA cloudfront cross-account
+tags: aws continuous deployment cdn spa cloudfront cross-account
 author: Pete Yandell
 image: img/inception-pipelines/seed_germination.png
 ---

--- a/_posts/2018-05-18-inception-pipelines-pt3.markdown
+++ b/_posts/2018-05-18-inception-pipelines-pt3.markdown
@@ -13,7 +13,7 @@ image: img/inception-pipelines/seed_germination.png
 
 ## What's The Problem
 
-Welcome back to the 3rd instalment in the "Seeds of Inception" series, where we build upon [Part 2](https://mechanicalrock.github.io//aws/continuous/deployment/cdn/spa/cloudfront/2018/04/01/inception-pipelines-pt2) by setting our pipelines to 'defrost'. By this I mean solving the snowflake environment issue that plagues software development; where each environment is unique and special and just a little bit different from all the others in the DEV to PROD chain.
+Welcome back to the 3rd instalment in the "Seeds of Inception" series, where we build upon [Part 2]({{ site.baseurl }}{% post_url 2018-04-01-inception-pipelines-pt2 %}) by setting our pipelines to 'defrost'. By this I mean solving the snowflake environment issue that plagues software development; where each environment is unique and special and just a little bit different from all the others in the DEV to PROD chain.
 
 Getting down to the guts of it, I'll demonstrate one way to deploy your single `aws_infrastructure.yml` template across multiple AWS Accounts. All from the comfort of your very own [Inception Pipeline](https://github.com/MechanicalRock/InceptionPipeline/tree/post/part-3)
 
@@ -27,7 +27,7 @@ Getting down to the guts of it, I'll demonstrate one way to deploy your single `
 
 To get started, you will need the following:
 
-* Having [Part 2](https://mechanicalrock.github.io//aws/continuous/deployment/cdn/spa/cloudfront/2018/04/01/inception-pipelines-pt2) installed.
+* Having [Part 2]({{ site.baseurl }}{% post_url 2018-04-01-inception-pipelines-pt2 %}) installed.
 * Having a second 'production' AWS Account, and enough permissions to create a pipeline.
 
 ## How It All Works
@@ -64,7 +64,7 @@ Rather than repeat what every file is, I'll just talk about the really interesti
 
 If you've been following along with these posts then it is a simple as diffing the files and copying across the relevant bits for `aws_seed.yml` and any of the other files you're missing.
 
-If not (I'll try not to judge you too much), you should be able to open a command prompt, change directory into either the `non-production` or `production` folder and then just follow the steps from [Part 1](http://localhost:4000/aws/continuous/deployment/2018/03/01/inception-pipelines-pt1.html)
+If not (I'll try not to judge you too much), you should be able to open a command prompt, change directory into either the `non-production` or `production` folder and then just follow the steps from [Part 1]({{ site.baseurl }}{% post_url 2018-03-01-inception-pipelines-pt1 %})
 
 ## Wrapping Up
 

--- a/_posts/2018-06-25-inception-pipelines-pt4.markdown
+++ b/_posts/2018-06-25-inception-pipelines-pt4.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Seeds of Inception - Part 4"
 date:   2018-06-25
-categories: aws continuous deployment codepipeline codebuild inception pipeline
+tags: aws continuous deployment codepipeline codebuild inception pipeline
 author: Pete Yandell
 image: img/inception-pipelines/seed_germination.png
 ---

--- a/_posts/2018-06-25-inception-pipelines-pt4.markdown
+++ b/_posts/2018-06-25-inception-pipelines-pt4.markdown
@@ -21,7 +21,7 @@ None, nada, zero, zilch. So, put away the IDE, shutdown the AWS Console and brew
 
 ## What Are The Prerequisites
 
-Not much this month. If you've read [Part 1](https://mechanicalrock.github.io/aws/continuous/deployment/2018/03/01/inception-pipelines-pt1) then that's pretty much it.
+Not much this month. If you've read [Part 1]({{ site.baseurl }}{% post_url 2018-03-01-inception-pipelines-pt1 %}) then that's pretty much it.
 
 ## How It All Works
 

--- a/_posts/2018-07-17-its-a-lot-more-snappy.md
+++ b/_posts/2018-07-17-its-a-lot-more-snappy.md
@@ -2,7 +2,7 @@
 layout: post
 title: "\"It's A Lot More Snappy\""
 date: 2018-07-29
-tags: PWA SPA JavaScript
+tags: pwa spa javascript
 author: Rick Foxcroft
 image: img/offline_logo.png
 ---

--- a/_posts/2018-07-17-its-a-lot-more-snappy.md
+++ b/_posts/2018-07-17-its-a-lot-more-snappy.md
@@ -2,7 +2,7 @@
 layout: post
 title: "\"It's A Lot More Snappy\""
 date: 2018-07-29
-categories: PWA SPA JavaScript
+tags: PWA SPA JavaScript
 author: Rick Foxcroft
 image: img/offline_logo.png
 ---

--- a/_posts/2018-07-31-inception-pipelines-pt5.markdown
+++ b/_posts/2018-07-31-inception-pipelines-pt5.markdown
@@ -13,7 +13,7 @@ image: img/inception-pipelines/seed_germination.png
 
 ## What's The Problem
 
-This month we're building on [last month's post](https://mechanicalrock.github.io//aws/continuous/deployment/codepipeline/codebuild/inception/pipeline/2018/06/25/inception-pipelines-pt4) and discussing one approach to managing IAM users across multiple accounts. More specifically we're avoiding the quick, dirty and lazy way of just throwing IAM users into each account. When you do, you quickly end up with an unmanageable jungle of profiles and access keys, which creates an increased exposure to compromised accounts. So here is a better way; read on fair explorers while we cut a path through this jungle to IAM user nirvana.
+This month we're building on [last month's post]({{ site.baseurl }}{% post_url 2018-06-25-inception-pipelines-pt4 %}) and discussing one approach to managing IAM users across multiple accounts. More specifically we're avoiding the quick, dirty and lazy way of just throwing IAM users into each account. When you do, you quickly end up with an unmanageable jungle of profiles and access keys, which creates an increased exposure to compromised accounts. So here is a better way; read on fair explorers while we cut a path through this jungle to IAM user nirvana.
 
 It is worth explicitly calling out that the ideas discussed below are more targeted towards smaller AWS installations. [Reach out](https://www.mechanicalrock.io/#/contact-us) to us to discuss alternatives if you are working in a large corporate environment with a dedicated user directory and tens or hundreds of AWS Accounts.
 
@@ -132,7 +132,7 @@ If you had multiple roles, then copy-and-paste the above and give it another nam
 
 ## Where Do I Get The Seed Files
 
-Two complete, working pipelines are available [here on GitHub](https://github.com/MechanicalRock/InceptionPipeline/tree/post/part-5) with one pipeline for your root account and one for your child account. As discussed in the [last post](https://mechanicalrock.github.io//aws/continuous/deployment/codepipeline/codebuild/inception/pipeline/2018/06/25/inception-pipelines-pt4), these would be considered account-level pipelines.
+Two complete, working pipelines are available [here on GitHub](https://github.com/MechanicalRock/InceptionPipeline/tree/post/part-5) with one pipeline for your root account and one for your child account. As discussed in the [last post]({{ site.baseurl }}{% post_url 2018-06-25-inception-pipelines-pt4 %}), these would be considered account-level pipelines.
 
 ### What Are The Files
 
@@ -144,7 +144,7 @@ Two complete, working pipelines are available [here on GitHub](https://github.co
 
 ## Taking It For A Spin
 
-If you're new to [Inception Pipelines](https://mechanicalrock.github.io//aws/continuous/deployment/2018/03/01/inception-pipelines-pt1), head on over to the [original post](https://mechanicalrock.github.io//aws/continuous/deployment/2018/03/01/inception-pipelines-pt1) and set yourself up a pipeline. If not, copy over the files referenced above, add in the appropriate pipeline action and commit. Enjoy!
+If you're new to [Inception Pipelines]({{ site.baseurl }}{% post_url 2018-03-01-inception-pipelines-pt1 %}), head on over to the [original post]({{ site.baseurl }}{% post_url 2018-03-01-inception-pipelines-pt1 %}) and set yourself up a pipeline. If not, copy over the files referenced above, add in the appropriate pipeline action and commit. Enjoy!
 
 ## Wrapping Up
 

--- a/_posts/2018-07-31-inception-pipelines-pt5.markdown
+++ b/_posts/2018-07-31-inception-pipelines-pt5.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Seeds of Inception - Part 5"
 date:   2018-07-31
-categories: aws codepipeline inception pipeline iam cross-account roles users groups
+tags: aws codepipeline inception pipeline iam cross-account roles users groups
 author: Pete Yandell
 image: img/inception-pipelines/seed_germination.png
 ---

--- a/about.md
+++ b/about.md
@@ -1,5 +1,0 @@
----
-layout: page
-title: About
-permalink: /about/
----

--- a/tags.md
+++ b/tags.md
@@ -6,7 +6,7 @@ permalink: /tags/
 <p>
 {% for tag in site.tags %}
   {% assign t = tag | first %}
-  <a style="background: #F6F6F6" href="/tags/#{{ t }}">{{ t | replace:" ", "," }}</a>
+  <a style="background: #F6F6F6" href="/tags/#{{ t }}">{{ t }}</a>
 {% endfor %}
 </p>
 {% for tag in site.tags %}

--- a/tags.md
+++ b/tags.md
@@ -1,0 +1,45 @@
+---
+layout: page
+title: Tags
+permalink: /tags/
+---
+<p>
+{% for tag in site.tags %}
+  {% assign t = tag | first %}
+  <a style="background: #F6F6F6" href="/tags/#{{ t }}">{{ t | replace:" ", "," }}</a>
+{% endfor %}
+</p>
+{% for tag in site.tags %}
+  {% assign t = tag | first %}
+  {% assign posts = tag | last %}
+
+  <p><a name="{{ t }}"></a><a href="/tags/#{{ t }}">{{ t}}</a></p>
+  <ul>
+  {% for post in posts %}
+    {% if post.tags contains t %}
+    <li>
+      <a href="{{ post.url }}">{{ post.title }}</a>
+      <span>{{ post.date | date: "%B %-d, %Y"  }}</span>
+    </li>
+    {% endif %}
+  {% endfor %}
+  </ul>
+{% endfor %}
+
+<!--
+{% for tag in site.tags %}
+  {% assign t = tag | first %}
+  {% assign posts = tag | last %}
+
+{{ t | downcase }}
+<ul>
+{% for post in posts %}
+  {% if post.tags contains t %}
+  <li>
+    <a href="{{ post.url }}">{{ post.title }}</a>
+    <span class="date">{{ post.date | date: "%B %-d, %Y"  }}</span>
+  </li>
+  {% endif %}
+{% endfor %}
+</ul>
+{% endfor %} -->

--- a/tags.md
+++ b/tags.md
@@ -4,16 +4,17 @@ title: Tags
 permalink: /tags/
 ---
 <p>
-{% for tag in site.tags %}
+{% assign sorted_tags = site.tags | sort %}
+{% for tag in sorted_tags %}
   {% assign t = tag | first %}
   <a style="background: #F6F6F6" href="/tags/#{{ t }}">{{ t }}</a>
 {% endfor %}
 </p>
-{% for tag in site.tags %}
+{% for tag in sorted_tags %}
   {% assign t = tag | first %}
   {% assign posts = tag | last %}
 
-  <p><a name="{{ t }}"></a><a href="/tags/#{{ t }}">{{ t}}</a></p>
+  <p><a name="{{ t }}"></a><a href="/tags/#{{ t }}">{{ t }}</a></p>
   <ul>
   {% for post in posts %}
     {% if post.tags contains t %}

--- a/tags.md
+++ b/tags.md
@@ -25,21 +25,3 @@ permalink: /tags/
   {% endfor %}
   </ul>
 {% endfor %}
-
-<!--
-{% for tag in site.tags %}
-  {% assign t = tag | first %}
-  {% assign posts = tag | last %}
-
-{{ t | downcase }}
-<ul>
-{% for post in posts %}
-  {% if post.tags contains t %}
-  <li>
-    <a href="{{ post.url }}">{{ post.title }}</a>
-    <span class="date">{{ post.date | date: "%B %-d, %Y"  }}</span>
-  </li>
-  {% endif %}
-{% endfor %}
-</ul>
-{% endfor %} -->


### PR DESCRIPTION
Building on from #21  which puts the categories of the posts onto each page, this PR makes a number of changes.

Categories are now tags!

## Tags
We now have a tag page which displays all the tags that the posts have on them. This provides an easy way to navigate around the site.
<img width="858" alt="screen shot 2018-07-31 at 4 53 21 pm" src="https://user-images.githubusercontent.com/8016590/43449268-93b70c2e-94e2-11e8-8ad3-e01f66aeef3e.png">

## Links
As illustrated above the tags are clickable on the tag page taking the user to the correct section as well as handy links to the post, but now if you are on a blog post already and want to see more posts based on a tag, you can click the tag and be taken to the relevant section on the tag index page.
<img width="341" alt="screen shot 2018-07-31 at 4 53 53 pm" src="https://user-images.githubusercontent.com/8016590/43449344-c54113d4-94e2-11e8-97e9-35f81be24760.png">

## Note on these changes:
The changes are breaking changes in that the page URL for the posts will only include the date and the post title. Categories _CAN_ be added as part of the post metadata if you wish, but these should be kept to an absolute minimum. 1 or 2 if necessary. This will put the category entered into the post's URL.