### PR TITLE
Update 404 page to provide link to blog index

### DIFF
--- a/404.html
+++ b/404.html
@@ -20,5 +20,6 @@ layout: default
   <h1>404</h1>
 
   <p><strong>Page not found :(</strong></p>
-  <p>The requested page could not be found.</p>
+  <p>The blog has recently undergone some structural change and the requested page could not be found. Sorry about that!</p>
+  <p>Take a look at the <a href={{ site.url }}>Home Page</a> to see if you can find the page you were looking for there.</p>
 </div>


### PR DESCRIPTION
Pipeline Pete raised a point about what happens to 404 pages since now that the links that were created prior to the change are broken.

This PR adds a helpful message on the 404 page and provides a link to the index.