### PR TITLE
Update typo in title of event bridge post

### DIFF
--- a/_posts/2019-07-22-aws-event-bridge.md
+++ b/_posts/2019-07-22-aws-event-bridge.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: AWS Annouces Event Bridge
+title: AWS Announces Event Bridge
 date: 2019-07-26
 tags: aws event-bridge
 author: JK Gunnink


### PR DESCRIPTION
After I updated the title, didn't realise there was a typo. This fixes that.