### PR TITLE
Add regenerate to Front Matter of index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,4 +3,5 @@
 # Edit theme's home layout instead if you wanna make some changes
 # See: https://jekyllrb.com/docs/themes/#overriding-theme-defaults
 layout: home
+regenerate: true
 ---


### PR DESCRIPTION
When we add a new post to `_post` the following happens:

1. The new post is compiled into html
2. This file is then placed into `_site/{yyyy}/{mm}/`
3. The `_site/pages` directory is recompiled - which contains the html for the second page of posts to the last page of posts

However if a post needs to appear on the home page ie. index.html, we run into an issue as when we add a post, the _site/index.html file does not get regenerated. This does not get regenerated due to the `--incremental` flag we use in the Dockerfile when we serve Jekyll. Using the --incremental flag means only watched files will be regenerated. `index.html` is not a watched file. Adding the `regenerate` flag to the Front Matter of the `index.html` forces a recompile.

https://jekyllrb.com/docs/configuration/incremental-regeneration/