### PR TITLE
fix: twitter image head tag

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -48,7 +48,7 @@
   <meta name="twitter:data1" content="{{ page.readingTime }}">
   {% endif %}
   {% if page.image %}
-  <meta name="twitter:image:src" content="{{ site.url }}/{{ page.image }}" />
+  <meta name="twitter:image" content="{{ site.url }}{{ page.image }}" />
   {% endif %}
 
   <meta property="article:published_time" content="{{ page.date }}">


### PR DESCRIPTION
Currently our blog images aren't rendering properly on Twitter, trying to solve it.

<img width="607" alt="Screen Shot 2021-05-28 at 11 33 49 am" src="https://user-images.githubusercontent.com/480823/119925733-94fdbd00-bfa8-11eb-9b20-e5220116e02d.png">
