### PR TITLE
added Jerkll sitemap generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ _site
 .vscode/
 .jekyll-cache/
 node_modules
+vendor

--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ group :jekyll_plugins do
    gem "jekyll-feed", "~> 0.15", ">= 0.15.0"
    gem "jemoji", "~> 0.12.0"
    gem "jekyll-paginate", "~> 1.1.0"
+   gem "jekyll-sitemap", "~> 1.4.0"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,8 @@ GEM
       sassc (> 2.0.1, < 3.0)
     jekyll-seo-tag (2.6.1)
       jekyll (>= 3.3, < 5.0)
+    jekyll-sitemap (1.4.0)
+      jekyll (>= 3.7, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     jemoji (0.12.0)
@@ -120,6 +122,7 @@ DEPENDENCIES
   jekyll (= 4.0.0)
   jekyll-feed (~> 0.15, >= 0.15.0)
   jekyll-paginate (~> 1.1.0)
+  jekyll-sitemap (~> 1.4.0)
   jemoji (~> 0.12.0)
   minima (~> 2.5, >= 2.5.1)
   tzinfo-data

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ highlight: monokai // [Optional] Will apply the monokai dark highlight theme to 
 tags: String | String[] // (Recommend 5 tags). Make sure your tags are what people Google Search. Make sure your tags are also mentioned in your blog post itself.
 author: String
 image: String // Relevant path directory to your image (do not prefix with a /)
+sitemap: Boolean // [Optional] By default articles are indexed in the sitemap.xml file. Setting this to false will remove it from the sitemap
 ---
 ```
 

--- a/_config.yml
+++ b/_config.yml
@@ -29,9 +29,16 @@ paginate_path: "/pages/:num/"
 markdown: kramdown
 theme: minima
 plugins:
+  - jekyll-sitemap
   - jekyll-feed
   - jemoji
   - jekyll-paginate
+
+defaults:
+  - scope:
+      path: "_site/pages/*"
+    values:
+      sitemap: false
 
 # Don't display future posts
 future: false


### PR DESCRIPTION
This configuration will output the following sitemap.xml file, real important for SEO crawlers to index all of our content:

<img width="816" alt="Screen Shot 2021-06-11 at 1 01 01 pm" src="https://user-images.githubusercontent.com/25266506/121633353-36126a80-cab5-11eb-8ec7-9e27d3d7b95d.png">

---

This will require everyone to rebuild their GEMs 🤔 