### PR TITLE
Set timezone to Australia/Perth

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -43,6 +43,9 @@ defaults:
 # Don't display future posts
 future: false
 
+# set timezone
+timezone: Australia/Perth
+
 # deployment
 host: 0.0.0.0
 port: 4000


### PR DESCRIPTION
From the Jekyll docs:

https://jekyllrb.com/docs/configuration/options/#global-configuration

> ... When serving on a local machine, the default time zone is set by your operating system. But when served on a remote host/server, the default time zone depends on the server's setting or location.

Background: https://mehmandarov.com/jekyll-content-on-time/
